### PR TITLE
Validation of parameter IN attribute

### DIFF
--- a/src/main/java/com/apiflows/model/Step.java
+++ b/src/main/java/com/apiflows/model/Step.java
@@ -100,6 +100,10 @@ public class Step {
         this.parameters = parameters;
     }
 
+    public void addParameter(Parameter parameter) {
+        this.parameters.add(parameter);
+    }
+
     @JsonProperty("successCriteria")
     public List<Criterion> getSuccessCriteria() {
         return successCriteria;

--- a/src/main/java/com/apiflows/parser/OpenAPIWorkflowValidator.java
+++ b/src/main/java/com/apiflows/parser/OpenAPIWorkflowValidator.java
@@ -165,6 +165,13 @@ public class OpenAPIWorkflowValidator {
         if(step.getParameters() != null) {
             for(Parameter parameter : step.getParameters()) {
                 errors.addAll(validateParameter(parameter, workflowId));
+
+                if(step.getWorkflowId() != null) {
+                    // when the step in context specifies a workflowId the parameter IN must be defined
+                    if(parameter.getIn() == null) {
+                        errors.add("'Workflow[" + workflowId + "]' parameter IN must be defined");
+                    }
+                }
             }
         }
 
@@ -208,13 +215,6 @@ public class OpenAPIWorkflowValidator {
 
             if(name == null) {
                 errors.add("'Workflow[" + workflowId + "]' parameter has no name");
-            }
-            if(parameter.getIn() == null) {
-                if(name != null) {
-                    errors.add("Parameter '" + name + "' has no type");
-                } else {
-                    errors.add("'Workflow[" + workflowId + "]' parameter has no type");
-                }
             }
             if(parameter.getIn() != null) {
                 if(!SUPPORTED_VALUES.contains(parameter.getIn())) {

--- a/src/test/java/com/apiflows/parser/OpenAPIWorkflowValidatorTest.java
+++ b/src/test/java/com/apiflows/parser/OpenAPIWorkflowValidatorTest.java
@@ -185,6 +185,22 @@ class OpenAPIWorkflowValidatorTest {
     }
 
     @Test
+    void validateStepWithoutInAttribute() {
+        Step step = new Step()
+                .stepId("step-one")
+                .description("First step in the workflow")
+                .workflowId("workflow-id-2");
+        step.addParameter(new Parameter()
+                .name("param")
+                .value("value"));
+
+        String worklowId = "q1";
+
+        assertEquals(1, validator.validateStep(step, worklowId).size());
+    }
+
+
+    @Test
     void validateParameter() {
         Parameter parameter = new Parameter()
                 .name("param")


### PR DESCRIPTION
Refactor validation to enforce `in` attribute when the step is not in the context of a workflow (e.g., a step specifies an operationId).