### PR TITLE
Implement missing Arazzo spec features

### DIFF
--- a/src/main/java/com/apiflows/model/Action.java
+++ b/src/main/java/com/apiflows/model/Action.java
@@ -1,0 +1,60 @@
+package com.apiflows.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class Action {
+
+    private String name;
+    private String type;
+    private String workflowId;
+    private String stepId;
+    private List<Criterion> criteria;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getWorkflowId() {
+        return workflowId;
+    }
+
+    public void setWorkflowId(String workflowId) {
+        this.workflowId = workflowId;
+    }
+
+    public String getStepId() {
+        return stepId;
+    }
+
+    public void setStepId(String stepId) {
+        this.stepId = stepId;
+    }
+
+    public List<Criterion> getCriteria() {
+        return criteria;
+    }
+
+    public void setCriteria(List<Criterion> criteria) {
+        this.criteria = criteria;
+    }
+
+    public void addCriteria(Criterion criterion) {
+        if (this.criteria == null) {
+            this.criteria = new ArrayList<>();
+        }
+        this.criteria.add(criterion);
+    }
+}

--- a/src/main/java/com/apiflows/model/Criterion.java
+++ b/src/main/java/com/apiflows/model/Criterion.java
@@ -1,12 +1,16 @@
 package com.apiflows.model;
 
+import com.apiflows.parser.util.CriterionTypeDeserializer;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 public class Criterion {
 
     private String condition;
     private String context;
-    private String type;
+
+    @JsonDeserialize(using = CriterionTypeDeserializer.class)
+    private Object type;
 
     public String getCondition() {
         return condition;
@@ -24,12 +28,23 @@ public class Criterion {
         this.context = context;
     }
 
+    /** Returns the simple string type (e.g. "simple", "regex") or null if an expression type object is used. */
+    @JsonProperty("type")
     public String getType() {
-        return type;
+        return type instanceof String ? (String) type : null;
     }
 
     public void setType(String type) {
         this.type = type;
+    }
+
+    /** Returns the expression type object when type is "jsonpath" or "xpath" with a version, or null otherwise. */
+    public CriterionExpressionType getExpressionType() {
+        return type instanceof CriterionExpressionType ? (CriterionExpressionType) type : null;
+    }
+
+    public void setExpressionType(CriterionExpressionType expressionType) {
+        this.type = expressionType;
     }
 
     public Criterion condition(String condition) {
@@ -44,6 +59,11 @@ public class Criterion {
 
     public Criterion type(String type) {
         this.type = type;
+        return this;
+    }
+
+    public Criterion expressionType(CriterionExpressionType expressionType) {
+        this.type = expressionType;
         return this;
     }
 }

--- a/src/main/java/com/apiflows/model/CriterionExpressionType.java
+++ b/src/main/java/com/apiflows/model/CriterionExpressionType.java
@@ -1,0 +1,37 @@
+package com.apiflows.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CriterionExpressionType {
+
+    private String type;
+    private String version;
+
+    @JsonProperty("type")
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    @JsonProperty("version")
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public CriterionExpressionType type(String type) {
+        this.type = type;
+        return this;
+    }
+
+    public CriterionExpressionType version(String version) {
+        this.version = version;
+        return this;
+    }
+}

--- a/src/main/java/com/apiflows/model/FailureAction.java
+++ b/src/main/java/com/apiflows/model/FailureAction.java
@@ -1,49 +1,9 @@
 package com.apiflows.model;
 
-import java.util.ArrayList;
-import java.util.List;
+public class FailureAction extends Action {
 
-public class FailureAction {
-
-    private String name;
-    private String type;
-    private String workflowId;
-    private String stepId;
     private Double retryAfter;
     private Integer retryLimit;
-    private List<Criterion> criteria;
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
-    }
-
-    public String getWorkflowId() {
-        return workflowId;
-    }
-
-    public void setWorkflowId(String workflowId) {
-        this.workflowId = workflowId;
-    }
-
-    public String getStepId() {
-        return stepId;
-    }
-
-    public void setStepId(String stepId) {
-        this.stepId = stepId;
-    }
 
     public Double getRetryAfter() {
         return retryAfter;
@@ -61,31 +21,23 @@ public class FailureAction {
         this.retryLimit = retryLimit;
     }
 
-    public List<Criterion> getCriteria() {
-        return criteria;
-    }
-
-    public void setCriteria(List<Criterion> criteria) {
-        this.criteria = criteria;
-    }
-
     public FailureAction name(String name) {
-        this.name = name;
+        setName(name);
         return this;
     }
 
     public FailureAction type(String type) {
-        this.type = type;
+        setType(type);
         return this;
     }
 
     public FailureAction stepId(String stepId) {
-        this.stepId = stepId;
+        setStepId(stepId);
         return this;
     }
 
     public FailureAction workflowId(String workflowId) {
-        this.workflowId = workflowId;
+        setWorkflowId(workflowId);
         return this;
     }
 
@@ -97,12 +49,5 @@ public class FailureAction {
     public FailureAction retryLimit(Integer retryLimit) {
         this.retryLimit = retryLimit;
         return this;
-    }
-
-    public void addCriteria(Criterion criterion) {
-        if(this.criteria == null) {
-            this.criteria = new ArrayList<>();
-        }
-        this.criteria.add(criterion);
     }
 }

--- a/src/main/java/com/apiflows/model/FailureAction.java
+++ b/src/main/java/com/apiflows/model/FailureAction.java
@@ -5,12 +5,21 @@ import java.util.List;
 
 public class FailureAction {
 
+    private String name;
     private String type;
     private String workflowId;
     private String stepId;
     private Double retryAfter;
     private Integer retryLimit;
     private List<Criterion> criteria;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
 
     public String getType() {
         return type;
@@ -58,6 +67,11 @@ public class FailureAction {
 
     public void setCriteria(List<Criterion> criteria) {
         this.criteria = criteria;
+    }
+
+    public FailureAction name(String name) {
+        this.name = name;
+        return this;
     }
 
     public FailureAction type(String type) {

--- a/src/main/java/com/apiflows/model/Info.java
+++ b/src/main/java/com/apiflows/model/Info.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class Info {
 
     private String title;
+    private String summary;
     private String version;
     private String description;
 
@@ -15,6 +16,15 @@ public class Info {
 
     public void setTitle(String title) {
         this.title = title;
+    }
+
+    @JsonProperty("summary")
+    public String getSummary() {
+        return summary;
+    }
+
+    public void setSummary(String summary) {
+        this.summary = summary;
     }
 
     @JsonProperty("version")
@@ -37,6 +47,11 @@ public class Info {
 
     public Info title(String title) {
         this.title = title;
+        return this;
+    }
+
+    public Info summary(String summary) {
+        this.summary = summary;
         return this;
     }
 

--- a/src/main/java/com/apiflows/model/Parameter.java
+++ b/src/main/java/com/apiflows/model/Parameter.java
@@ -6,7 +6,7 @@ public class Parameter {
 
     private String name;
     private String in;
-    private String value;
+    private Object value;
     private String reference;
 
     @JsonProperty("name")
@@ -28,11 +28,11 @@ public class Parameter {
     }
 
     @JsonProperty("value")
-    public String getValue() {
+    public Object getValue() {
         return value;
     }
 
-    public void setValue(String value) {
+    public void setValue(Object value) {
         this.value = value;
     }
 
@@ -55,7 +55,7 @@ public class Parameter {
         return this;
     }
 
-    public Parameter value(String value) {
+    public Parameter value(Object value) {
         this.value = value;
         return this;
     }

--- a/src/main/java/com/apiflows/model/SuccessAction.java
+++ b/src/main/java/com/apiflows/model/SuccessAction.java
@@ -5,10 +5,19 @@ import java.util.List;
 
 public class SuccessAction {
 
+    private String name;
     private String type;
     private String workflowId;
     private String stepId;
     private List<Criterion> criteria;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
 
     public String getType() {
         return type;
@@ -47,6 +56,11 @@ public class SuccessAction {
             this.criteria = new ArrayList<>();
         }
         this.criteria.add(criterion);
+    }
+
+    public SuccessAction name(String name) {
+        this.name = name;
+        return this;
     }
 
     public SuccessAction type(String type) {

--- a/src/main/java/com/apiflows/model/SuccessAction.java
+++ b/src/main/java/com/apiflows/model/SuccessAction.java
@@ -1,80 +1,24 @@
 package com.apiflows.model;
 
-import java.util.ArrayList;
-import java.util.List;
-
-public class SuccessAction {
-
-    private String name;
-    private String type;
-    private String workflowId;
-    private String stepId;
-    private List<Criterion> criteria;
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
-    }
-
-    public String getWorkflowId() {
-        return workflowId;
-    }
-
-    public void setWorkflowId(String workflowId) {
-        this.workflowId = workflowId;
-    }
-
-    public String getStepId() {
-        return stepId;
-    }
-
-    public void setStepId(String stepId) {
-        this.stepId = stepId;
-    }
-
-    public List<Criterion> getCriteria() {
-        return criteria;
-    }
-
-    public void setCriteria(List<Criterion> criteria) {
-        this.criteria = criteria;
-    }
-
-    public void addCriteria(Criterion criterion) {
-        if(this.criteria == null) {
-            this.criteria = new ArrayList<>();
-        }
-        this.criteria.add(criterion);
-    }
+public class SuccessAction extends Action {
 
     public SuccessAction name(String name) {
-        this.name = name;
+        setName(name);
         return this;
     }
 
     public SuccessAction type(String type) {
-        this.type = type;
+        setType(type);
         return this;
     }
 
     public SuccessAction workflowId(String workflowId) {
-        this.workflowId = workflowId;
+        setWorkflowId(workflowId);
         return this;
     }
 
     public SuccessAction stepId(String stepId) {
-        this.stepId = stepId;
+        setStepId(stepId);
         return this;
     }
 }

--- a/src/main/java/com/apiflows/model/Workflow.java
+++ b/src/main/java/com/apiflows/model/Workflow.java
@@ -15,7 +15,7 @@ public class Workflow {
     private String description;
     private Schema inputs;
 
-    private String dependsOn;
+    private List<String> dependsOn;
 
     private List<Parameter> parameters = new ArrayList<>();
     private List<SuccessAction> successActions = new ArrayList<>();
@@ -102,11 +102,11 @@ public class Workflow {
         return this;
     }
 
-    public String getDependsOn() {
+    public List<String> getDependsOn() {
         return dependsOn;
     }
 
-    public void setDependsOn(String dependsOn) {
+    public void setDependsOn(List<String> dependsOn) {
         this.dependsOn = dependsOn;
     }
 

--- a/src/main/java/com/apiflows/parser/OpenAPIWorkflowValidator.java
+++ b/src/main/java/com/apiflows/parser/OpenAPIWorkflowValidator.java
@@ -2,7 +2,6 @@ package com.apiflows.parser;
 
 import com.apiflows.model.*;
 import com.fasterxml.jackson.core.JsonPointer;
-import io.swagger.v3.oas.models.media.Schema;
 
 import java.util.*;
 import java.util.regex.Pattern;
@@ -38,6 +37,8 @@ public class OpenAPIWorkflowValidator {
         
         if (openAPIWorkflow.getArazzo() == null || openAPIWorkflow.getArazzo().isEmpty()) {
             result.addError("'arazzo' is undefined");
+        } else if (!isValidArazzoVersion(openAPIWorkflow.getArazzo())) {
+            result.addError("'arazzo' version '" + openAPIWorkflow.getArazzo() + "' is invalid (must match 1.0.x)");
         }
 
         // Info
@@ -100,6 +101,8 @@ public class OpenAPIWorkflowValidator {
             for (SourceDescription sourceDescription : sourceDescriptions) {
                 if (sourceDescription.getName() == null || sourceDescription.getName().isEmpty()) {
                     errors.add("'SourceDescription[" + i + "] name' is undefined");
+                } else if (!isValidSourceDescriptionName(sourceDescription.getName())) {
+                    errors.add("'SourceDescription[" + i + "] name' is invalid (must match ^[A-Za-z0-9_\\-]+$)");
                 }
                 if (sourceDescription.getUrl() == null || sourceDescription.getUrl().isEmpty()) {
                     errors.add("'SourceDescription[" + i + "] url' is undefined");
@@ -142,6 +145,13 @@ public class OpenAPIWorkflowValidator {
             }
         }
 
+        if (workflow.getDependsOn() != null) {
+            for (String dep : workflow.getDependsOn()) {
+                if (!workflowExists(dep)) {
+                    errors.add("Workflow[" + workflow.getWorkflowId() + "] dependsOn '" + dep + "' is invalid (no such workflow exists)");
+                }
+            }
+        }
 
         return errors;
     }
@@ -289,6 +299,10 @@ public class OpenAPIWorkflowValidator {
 
         List<String> errors = new ArrayList<>();
 
+        if (successAction.getName() == null || successAction.getName().isEmpty()) {
+            errors.add("Step " + stepId + " SuccessAction has no name");
+        }
+
         if (successAction.getType() == null) {
             errors.add("Step " + stepId + " SuccessAction has no type");
         }
@@ -320,6 +334,10 @@ public class OpenAPIWorkflowValidator {
         List<String> SUPPORTED_VALUES = Arrays.asList("end", "retry", "goto");
 
         List<String> errors = new ArrayList<>();
+
+        if (failureAction.getName() == null || failureAction.getName().isEmpty()) {
+            errors.add("Step " + stepId + " FailureAction has no name");
+        }
 
         if (failureAction.getType() == null) {
             errors.add("Step " + stepId + " FailureAction has no type");
@@ -358,7 +376,8 @@ public class OpenAPIWorkflowValidator {
     }
 
     List<String> validateCriterion(Criterion criterion, String stepId) {
-        List<String> SUPPORTED_VALUES = Arrays.asList("simple", "regex", "jsonpath", "xpath");
+        List<String> SUPPORTED_SIMPLE_TYPES = Arrays.asList("simple", "regex", "jsonpath", "xpath");
+        List<String> SUPPORTED_EXPRESSION_TYPES = Arrays.asList("jsonpath", "xpath");
 
         List<String> errors = new ArrayList<>();
 
@@ -366,12 +385,26 @@ public class OpenAPIWorkflowValidator {
             errors.add("Step " + stepId + " has no condition");
         }
 
-        if (criterion.getType() != null && !SUPPORTED_VALUES.contains(criterion.getType())) {
-            errors.add("Step " + stepId + " SuccessCriteria type (" + criterion.getType() + ") is invalid");
+        if (criterion.getType() != null) {
+            if (!SUPPORTED_SIMPLE_TYPES.contains(criterion.getType())) {
+                errors.add("Step " + stepId + " SuccessCriteria type (" + criterion.getType() + ") is invalid");
+            }
+            if (criterion.getContext() == null) {
+                errors.add("Step " + stepId + " SuccessCriteria type is specified but context is not provided");
+            }
         }
 
-        if (criterion.getType() != null && criterion.getContext() == null) {
-            errors.add("Step " + stepId + " SuccessCriteria type is specified but context is not provided");
+        CriterionExpressionType expressionType = criterion.getExpressionType();
+        if (expressionType != null) {
+            if (expressionType.getType() == null || !SUPPORTED_EXPRESSION_TYPES.contains(expressionType.getType())) {
+                errors.add("Step " + stepId + " SuccessCriteria expressionType '" + expressionType.getType() + "' is invalid (must be jsonpath or xpath)");
+            }
+            if (expressionType.getVersion() == null || expressionType.getVersion().isEmpty()) {
+                errors.add("Step " + stepId + " SuccessCriteria expressionType has no version");
+            }
+            if (criterion.getContext() == null) {
+                errors.add("Step " + stepId + " SuccessCriteria type is specified but context is not provided");
+            }
         }
 
         return errors;
@@ -399,6 +432,24 @@ public class OpenAPIWorkflowValidator {
                         errors.add("'Component input " + key + " is invalid (should match regex " + getComponentKeyRegularExpression() + ")");
                     }
                 }
+            }
+            if (components.getSuccessActions() != null) {
+                for (String key : components.getSuccessActions().keySet()) {
+                    if (!isValidComponentKey(key)) {
+                        errors.add("'Component successAction name " + key + " is invalid (should match regex " + getComponentKeyRegularExpression() + ")");
+                    }
+                }
+                components.getSuccessActions().forEach((key, action) ->
+                        errors.addAll(validateSuccessAction(null, key, action)));
+            }
+            if (components.getFailureActions() != null) {
+                for (String key : components.getFailureActions().keySet()) {
+                    if (!isValidComponentKey(key)) {
+                        errors.add("'Component failureAction name " + key + " is invalid (should match regex " + getComponentKeyRegularExpression() + ")");
+                    }
+                }
+                components.getFailureActions().forEach((key, action) ->
+                        errors.addAll(validateFailureAction(null, key, action)));
             }
         }
 
@@ -581,6 +632,14 @@ public class OpenAPIWorkflowValidator {
 
     boolean isRuntimeExpression(String name) {
         return name != null && name.startsWith("$");
+    }
+
+    boolean isValidArazzoVersion(String version) {
+        return Pattern.matches("^1\\.0\\.\\d+(-.+)?$", version);
+    }
+
+    boolean isValidSourceDescriptionName(String name) {
+        return Pattern.matches("^[A-Za-z0-9_\\-]+$", name);
     }
 
     private List<String> validateGotoTarget(String stepId, String actionLabel, String targetStepId, String targetWorkflowId) {

--- a/src/main/java/com/apiflows/parser/OpenAPIWorkflowValidator.java
+++ b/src/main/java/com/apiflows/parser/OpenAPIWorkflowValidator.java
@@ -8,6 +8,8 @@ import java.util.regex.Pattern;
 
 public class OpenAPIWorkflowValidator {
 
+    private static final String STEP_PREFIX = "Step ";
+
     private OpenAPIWorkflow openAPIWorkflow = null;
     Set<String> workflowIds = new HashSet<>();
     Map<String, Set<String>> stepIds = new HashMap<>();
@@ -283,16 +285,16 @@ public class OpenAPIWorkflowValidator {
         List<String> errors = new ArrayList<>();
 
         if (successAction.getName() == null || successAction.getName().isEmpty()) {
-            errors.add("Step " + stepId + " SuccessAction has no name");
+            errors.add(STEP_PREFIX + stepId + " SuccessAction has no name");
         }
 
         if (successAction.getType() == null) {
-            errors.add("Step " + stepId + " SuccessAction has no type");
+            errors.add(STEP_PREFIX + stepId + " SuccessAction has no type");
         }
 
         if (successAction.getType() != null) {
             if (!SUPPORTED_VALUES.contains(successAction.getType())) {
-                errors.add("Step " + stepId + " SuccessAction type (" + successAction.getType() + ") is invalid");
+                errors.add(STEP_PREFIX + stepId + " SuccessAction type (" + successAction.getType() + ") is invalid");
             }
         }
 
@@ -300,12 +302,12 @@ public class OpenAPIWorkflowValidator {
             errors.addAll(validateGotoTarget(stepId, "SuccessAction", successAction.getStepId(), successAction.getWorkflowId()));
             if(successAction.getStepId() != null) {
                 if (!stepExists(workflowId, successAction.getStepId())) {
-                    errors.add("Step " + stepId + " SuccessAction stepId is invalid (no such a step exists)");
+                    errors.add(STEP_PREFIX + stepId + " SuccessAction stepId is invalid (no such a step exists)");
                 }
             }
             if(successAction.getWorkflowId() != null) {
                 if(!workflowExists(successAction.getWorkflowId())) {
-                    errors.add("Step " + stepId + " SuccessAction workflowId is invalid (no such a workflow exists)");
+                    errors.add(STEP_PREFIX + stepId + " SuccessAction workflowId is invalid (no such a workflow exists)");
                 }
             }
         }
@@ -319,16 +321,16 @@ public class OpenAPIWorkflowValidator {
         List<String> errors = new ArrayList<>();
 
         if (failureAction.getName() == null || failureAction.getName().isEmpty()) {
-            errors.add("Step " + stepId + " FailureAction has no name");
+            errors.add(STEP_PREFIX + stepId + " FailureAction has no name");
         }
 
         if (failureAction.getType() == null) {
-            errors.add("Step " + stepId + " FailureAction has no type");
+            errors.add(STEP_PREFIX + stepId + " FailureAction has no type");
         }
 
         if (failureAction.getType() != null) {
             if (!SUPPORTED_VALUES.contains(failureAction.getType())) {
-                errors.add("Step " + stepId + " FailureAction type (" + failureAction.getType() + ") is invalid");
+                errors.add(STEP_PREFIX + stepId + " FailureAction type (" + failureAction.getType() + ") is invalid");
             }
         }
 
@@ -337,12 +339,12 @@ public class OpenAPIWorkflowValidator {
         }
 
         if(failureAction.getRetryAfter() != null && failureAction.getRetryAfter() < 0) {
-            errors.add("Step " + stepId + " FailureAction retryAfter must be non-negative");
+            errors.add(STEP_PREFIX + stepId + " FailureAction retryAfter must be non-negative");
 
         }
 
         if(failureAction.getRetryLimit() != null && failureAction.getRetryLimit() < 0) {
-            errors.add("Step " + stepId + " FailureAction retryLimit must be non-negative");
+            errors.add(STEP_PREFIX + stepId + " FailureAction retryLimit must be non-negative");
 
         }
 
@@ -350,7 +352,7 @@ public class OpenAPIWorkflowValidator {
                 && (failureAction.getType().equals("goto") || failureAction.getType().equals("retry"))) {
             // when type `goto` or `retry` stepId must exist (if provided)
             if (!stepExists(workflowId, failureAction.getStepId())) {
-                errors.add("Step " + stepId + " FailureAction stepId is invalid (no such a step exists)");
+                errors.add(STEP_PREFIX + stepId + " FailureAction stepId is invalid (no such a step exists)");
             }
         }
 
@@ -365,28 +367,28 @@ public class OpenAPIWorkflowValidator {
         List<String> errors = new ArrayList<>();
 
         if(criterion.getCondition() == null) {
-            errors.add("Step " + stepId + " has no condition");
+            errors.add(STEP_PREFIX + stepId + " has no condition");
         }
 
         if (criterion.getType() != null) {
             if (!SUPPORTED_SIMPLE_TYPES.contains(criterion.getType())) {
-                errors.add("Step " + stepId + " SuccessCriteria type (" + criterion.getType() + ") is invalid");
+                errors.add(STEP_PREFIX + stepId + " SuccessCriteria type (" + criterion.getType() + ") is invalid");
             }
             if (criterion.getContext() == null) {
-                errors.add("Step " + stepId + " SuccessCriteria type is specified but context is not provided");
+                errors.add(STEP_PREFIX + stepId + " SuccessCriteria type is specified but context is not provided");
             }
         }
 
         CriterionExpressionType expressionType = criterion.getExpressionType();
         if (expressionType != null) {
             if (expressionType.getType() == null || !SUPPORTED_EXPRESSION_TYPES.contains(expressionType.getType())) {
-                errors.add("Step " + stepId + " SuccessCriteria expressionType '" + expressionType.getType() + "' is invalid (must be jsonpath or xpath)");
+                errors.add(STEP_PREFIX + stepId + " SuccessCriteria expressionType '" + expressionType.getType() + "' is invalid (must be jsonpath or xpath)");
             }
             if (expressionType.getVersion() == null || expressionType.getVersion().isEmpty()) {
-                errors.add("Step " + stepId + " SuccessCriteria expressionType has no version");
+                errors.add(STEP_PREFIX + stepId + " SuccessCriteria expressionType has no version");
             }
             if (criterion.getContext() == null) {
-                errors.add("Step " + stepId + " SuccessCriteria type is specified but context is not provided");
+                errors.add(STEP_PREFIX + stepId + " SuccessCriteria type is specified but context is not provided");
             }
         }
 
@@ -646,10 +648,10 @@ public class OpenAPIWorkflowValidator {
     private List<String> validateGotoTarget(String stepId, String actionLabel, String targetStepId, String targetWorkflowId) {
         List<String> errors = new ArrayList<>();
         if (targetWorkflowId == null && targetStepId == null) {
-            errors.add("Step " + stepId + " " + actionLabel + " must define either workflowId or stepId");
+            errors.add(STEP_PREFIX + stepId + " " + actionLabel + " must define either workflowId or stepId");
         }
         if (targetWorkflowId != null && targetStepId != null) {
-            errors.add("Step " + stepId + " " + actionLabel + " cannot define both workflowId and stepId");
+            errors.add(STEP_PREFIX + stepId + " " + actionLabel + " cannot define both workflowId and stepId");
         }
         return errors;
     }

--- a/src/main/java/com/apiflows/parser/OpenAPIWorkflowValidator.java
+++ b/src/main/java/com/apiflows/parser/OpenAPIWorkflowValidator.java
@@ -181,24 +181,7 @@ public class OpenAPIWorkflowValidator {
             }
         }
 
-        if(step.getParameters() != null) {
-            for(Parameter parameter : step.getParameters()) {
-                if(isRuntimeExpression(parameter.getReference())) {
-                    // reference a reusable object
-                    errors.addAll(validateReusableParameter(parameter, workflowId, null));
-                } else {
-                    // parameter
-                    errors.addAll(validateParameter(parameter, workflowId, null));
-
-                    if(step.getWorkflowId() == null) {
-                        // when the step in context is NOT a workflowId the parameter IN must be defined
-                        if(!isRuntimeExpression(parameter.getName()) && parameter.getIn() == null) {
-                            errors.add("'Workflow[" + workflowId + "]' parameter IN must be defined");
-                        }
-                    }
-                }
-            }
-        }
+        errors.addAll(validateStepParameters(step, workflowId));
 
         if(step.getDependsOn() != null) {
             if(!stepExists(workflowId, step.getDependsOn())) {
@@ -640,6 +623,24 @@ public class OpenAPIWorkflowValidator {
 
     boolean isValidSourceDescriptionName(String name) {
         return Pattern.matches("^[A-Za-z0-9_\\-]+$", name);
+    }
+
+    private List<String> validateStepParameters(Step step, String workflowId) {
+        List<String> errors = new ArrayList<>();
+        if (step.getParameters() == null) {
+            return errors;
+        }
+        for (Parameter parameter : step.getParameters()) {
+            if (isRuntimeExpression(parameter.getReference())) {
+                errors.addAll(validateReusableParameter(parameter, workflowId, null));
+            } else {
+                errors.addAll(validateParameter(parameter, workflowId, null));
+                if (step.getWorkflowId() == null && !isRuntimeExpression(parameter.getName()) && parameter.getIn() == null) {
+                    errors.add("'Workflow[" + workflowId + "]' parameter IN must be defined");
+                }
+            }
+        }
+        return errors;
     }
 
     private List<String> validateGotoTarget(String stepId, String actionLabel, String targetStepId, String targetWorkflowId) {

--- a/src/main/java/com/apiflows/parser/util/CriterionTypeDeserializer.java
+++ b/src/main/java/com/apiflows/parser/util/CriterionTypeDeserializer.java
@@ -1,0 +1,35 @@
+package com.apiflows.parser.util;
+
+import com.apiflows.model.CriterionExpressionType;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+
+public class CriterionTypeDeserializer extends StdDeserializer<Object> {
+
+    public CriterionTypeDeserializer() {
+        super(Object.class);
+    }
+
+    @Override
+    public Object deserialize(JsonParser p, DeserializationContext ctx) throws IOException {
+        JsonNode node = p.getCodec().readTree(p);
+        if (node.isTextual()) {
+            return node.asText();
+        }
+        if (node.isObject()) {
+            CriterionExpressionType expressionType = new CriterionExpressionType();
+            if (node.has("type")) {
+                expressionType.setType(node.get("type").asText());
+            }
+            if (node.has("version")) {
+                expressionType.setVersion(node.get("version").asText());
+            }
+            return expressionType;
+        }
+        return null;
+    }
+}

--- a/src/test/java/com/apiflows/parser/OpenAPIWorkflowValidatorTest.java
+++ b/src/test/java/com/apiflows/parser/OpenAPIWorkflowValidatorTest.java
@@ -2,7 +2,6 @@ package com.apiflows.parser;
 
 import com.apiflows.model.*;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.BeforeEach;
 
 import java.util.*;
 

--- a/src/test/java/com/apiflows/parser/OpenAPIWorkflowValidatorTest.java
+++ b/src/test/java/com/apiflows/parser/OpenAPIWorkflowValidatorTest.java
@@ -2,6 +2,7 @@ package com.apiflows.parser;
 
 import com.apiflows.model.*;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.util.*;
 
@@ -54,7 +55,7 @@ class OpenAPIWorkflowValidatorTest {
     void validateSourceDescriptionsWithoutUrl() {
         List<SourceDescription> sourceDescriptions = new ArrayList<>();
         sourceDescriptions.add(new SourceDescription()
-                .name("Source one")
+                .name("source-one")
                 .type("openapi")
                 .url(null));
         assertEquals(1, validator.validateSourceDescriptions(sourceDescriptions).size());
@@ -64,7 +65,7 @@ class OpenAPIWorkflowValidatorTest {
     void validateSourceDescriptionsInvalidType() {
         List<SourceDescription> sourceDescriptions = new ArrayList<>();
         sourceDescriptions.add(new SourceDescription()
-                .name("Source one")
+                .name("source-one")
                 .type("unkwown")
                 .url("https://example.com/spec.json"));
         assertEquals(1, validator.validateSourceDescriptions(sourceDescriptions).size());
@@ -295,6 +296,7 @@ class OpenAPIWorkflowValidatorTest {
         String stepId = "step-one";
 
         SuccessAction successAction = new SuccessAction()
+                .name("on-success")
                 .type("end");
 
         successAction.addCriteria(
@@ -310,6 +312,7 @@ class OpenAPIWorkflowValidatorTest {
         String stepId = "step-one";
 
         SuccessAction successAction = new SuccessAction()
+                .name("on-success")
                 .type("end")
                 .stepId(null)
                 .workflowId(null);
@@ -323,6 +326,7 @@ class OpenAPIWorkflowValidatorTest {
         String stepId = "step-one";
 
         SuccessAction successAction = new SuccessAction()
+                .name("on-success")
                 .type("invalid-type")
                 .stepId("step-one");
 
@@ -339,6 +343,7 @@ class OpenAPIWorkflowValidatorTest {
         String stepId = "step-one";
 
         SuccessAction successAction = new SuccessAction()
+                .name("on-success")
                 .type("goto")
                 .stepId(null)
                 .workflowId(null);
@@ -352,6 +357,7 @@ class OpenAPIWorkflowValidatorTest {
         v.workflowIds.add("target-workflow");
 
         SuccessAction successAction = new SuccessAction()
+                .name("on-success")
                 .type("goto")
                 .stepId("step-one")
                 .workflowId("target-workflow");
@@ -364,6 +370,7 @@ class OpenAPIWorkflowValidatorTest {
         OpenAPIWorkflowValidator v = validatorWithWorkflowIds("target-workflow");
 
         SuccessAction successAction = new SuccessAction()
+                .name("on-success")
                 .type("goto")
                 .workflowId("target-workflow");
 
@@ -375,6 +382,7 @@ class OpenAPIWorkflowValidatorTest {
         OpenAPIWorkflowValidator v = validatorWithWorkflowIds("w1");
 
         SuccessAction successAction = new SuccessAction()
+                .name("on-success")
                 .type("goto")
                 .workflowId("non-existent-workflow");
 
@@ -386,6 +394,7 @@ class OpenAPIWorkflowValidatorTest {
         OpenAPIWorkflowValidator v = validatorWithStepIds("w1", "step-one", "step-two", "step-three");
 
         SuccessAction successAction = new SuccessAction()
+                .name("on-success")
                 .type("goto")
                 .stepId("step-dummy");
 
@@ -444,6 +453,7 @@ class OpenAPIWorkflowValidatorTest {
         String stepId = "step-one";
 
         FailureAction failureAction = new FailureAction()
+                .name("on-failure")
                 .type("end")
                 .retryAfter(1.5)
                 .retryLimit(3);
@@ -461,6 +471,7 @@ class OpenAPIWorkflowValidatorTest {
         String stepId = "step-one";
 
         FailureAction failureAction = new FailureAction()
+                .name("on-failure")
                 .type("dummy")
                 .retryAfter(1.5)
                 .retryLimit(3);
@@ -478,6 +489,7 @@ class OpenAPIWorkflowValidatorTest {
         String stepId = "step-one";
 
         FailureAction failureAction = new FailureAction()
+                .name("on-failure")
                 .type("end")
                 .retryAfter(-1.5)
                 .retryLimit(-3);
@@ -495,6 +507,7 @@ class OpenAPIWorkflowValidatorTest {
         String stepId = "step-one";
 
         FailureAction failureAction = new FailureAction()
+                .name("on-failure")
                 .type("retry")
                 .stepId(null)
                 .workflowId(null)
@@ -510,6 +523,7 @@ class OpenAPIWorkflowValidatorTest {
         String stepId = "step-one";
 
         FailureAction failureAction = new FailureAction()
+                .name("on-failure")
                 .type("goto")
                 .stepId(null)
                 .workflowId(null);
@@ -522,6 +536,7 @@ class OpenAPIWorkflowValidatorTest {
         OpenAPIWorkflowValidator v = validatorWithStepIds("w1", "step-one", "step-two");
 
         FailureAction failureAction = new FailureAction()
+                .name("on-failure")
                 .type("goto")
                 .stepId("step-one")
                 .workflowId("workflow-test");
@@ -535,6 +550,7 @@ class OpenAPIWorkflowValidatorTest {
         String stepId = "step-one";
 
         FailureAction failureAction = new FailureAction()
+                .name("on-failure")
                 .type("retry")
                 .retryAfter(0.5)
                 .retryLimit(3);
@@ -547,6 +563,7 @@ class OpenAPIWorkflowValidatorTest {
         OpenAPIWorkflowValidator v = validatorWithStepIds("w1", "step-one", "step-two", "step-three");
 
         FailureAction failureAction = new FailureAction()
+                .name("on-failure")
                 .type("retry")
                 .stepId("step-dummy")
                 .retryAfter(1.5)
@@ -755,6 +772,194 @@ class OpenAPIWorkflowValidatorTest {
         assertFalse(new OpenAPIWorkflowValidator().isValidComponentKey("pagination order"));
     }
 
+
+    // --- New feature tests ---
+
+    @Test
+    void validateArazzoVersionValid() {
+        assertTrue(new OpenAPIWorkflowValidator().isValidArazzoVersion("1.0.0"));
+    }
+
+    @Test
+    void validateArazzoVersionValidWithPrerelease() {
+        assertTrue(new OpenAPIWorkflowValidator().isValidArazzoVersion("1.0.1-beta"));
+    }
+
+    @Test
+    void validateArazzoVersionInvalid() {
+        assertFalse(new OpenAPIWorkflowValidator().isValidArazzoVersion("2.0.0"));
+    }
+
+    @Test
+    void validateArazzoVersionInvalidFormat() {
+        assertFalse(new OpenAPIWorkflowValidator().isValidArazzoVersion("1.0"));
+    }
+
+    @Test
+    void validateSourceDescriptionNameValid() {
+        assertTrue(new OpenAPIWorkflowValidator().isValidSourceDescriptionName("my-source_1"));
+    }
+
+    @Test
+    void validateSourceDescriptionNameInvalidWithSpace() {
+        assertFalse(new OpenAPIWorkflowValidator().isValidSourceDescriptionName("my source"));
+    }
+
+    @Test
+    void validateSourceDescriptionNameInvalidWithDot() {
+        assertFalse(new OpenAPIWorkflowValidator().isValidSourceDescriptionName("my.source"));
+    }
+
+    @Test
+    void validateSourceDescriptionInvalidName() {
+        List<SourceDescription> sourceDescriptions = new ArrayList<>();
+        sourceDescriptions.add(new SourceDescription()
+                .name("invalid name")
+                .type("openapi")
+                .url("https://example.com/spec.json"));
+        assertEquals(1, validator.validateSourceDescriptions(sourceDescriptions).size());
+    }
+
+    @Test
+    void validateSuccessActionMissingName() {
+        SuccessAction successAction = new SuccessAction()
+                .type("end");
+
+        assertEquals(1, validator.validateSuccessAction("w1", "step-one", successAction).size());
+    }
+
+    @Test
+    void validateFailureActionMissingName() {
+        FailureAction failureAction = new FailureAction()
+                .type("end");
+
+        assertEquals(1, validator.validateFailureAction("w1", "step-one", failureAction).size());
+    }
+
+    @Test
+    void validateWorkflowDependsOnValid() {
+        OpenAPIWorkflowValidator v = new OpenAPIWorkflowValidator();
+        v.workflowIds.add("w1");
+        v.workflowIds.add("w2");
+
+        Workflow workflow = new Workflow()
+                .workflowId("w2")
+                .addStep(new Step().stepId("step-one").operationId("op"));
+        workflow.setDependsOn(List.of("w1"));
+
+        assertEquals(0, v.validateWorkflow(workflow, 0).size());
+    }
+
+    @Test
+    void validateWorkflowDependsOnInvalid() {
+        OpenAPIWorkflowValidator v = new OpenAPIWorkflowValidator();
+        v.workflowIds.add("w1");
+
+        Workflow workflow = new Workflow()
+                .workflowId("w1")
+                .addStep(new Step().stepId("step-one").operationId("op"));
+        workflow.setDependsOn(List.of("non-existent-workflow"));
+
+        assertEquals(1, v.validateWorkflow(workflow, 0).size());
+    }
+
+    @Test
+    void validateCriterionWithExpressionType() {
+        Criterion criterion = new Criterion()
+                .condition("$.petId")
+                .context("$response.body")
+                .expressionType(new CriterionExpressionType()
+                        .type("jsonpath")
+                        .version("draft-goessner-dispatch-jsonpath-00"));
+
+        assertEquals(0, validator.validateCriterion(criterion, "step-one").size());
+    }
+
+    @Test
+    void validateCriterionExpressionTypeMissingVersion() {
+        Criterion criterion = new Criterion()
+                .condition("$.petId")
+                .context("$response.body")
+                .expressionType(new CriterionExpressionType()
+                        .type("jsonpath"));
+
+        assertEquals(1, validator.validateCriterion(criterion, "step-one").size());
+    }
+
+    @Test
+    void validateCriterionExpressionTypeInvalidType() {
+        Criterion criterion = new Criterion()
+                .condition("$.petId")
+                .context("$response.body")
+                .expressionType(new CriterionExpressionType()
+                        .type("simple")
+                        .version("draft-goessner-dispatch-jsonpath-00"));
+
+        assertEquals(1, validator.validateCriterion(criterion, "step-one").size());
+    }
+
+    @Test
+    void validateCriterionExpressionTypeMissingContext() {
+        Criterion criterion = new Criterion()
+                .condition("$.petId")
+                .expressionType(new CriterionExpressionType()
+                        .type("jsonpath")
+                        .version("draft-goessner-dispatch-jsonpath-00"));
+
+        assertEquals(1, validator.validateCriterion(criterion, "step-one").size());
+    }
+
+    @Test
+    void validateComponentsSuccessActions() {
+        Components components = new Components();
+        components.getSuccessActions().put("onSuccess", new SuccessAction().name("onSuccess").type("end"));
+
+        assertEquals(0, validator.validateComponents(components).size());
+    }
+
+    @Test
+    void validateComponentsSuccessActionsInvalidKey() {
+        Components components = new Components();
+        components.getSuccessActions().put("on success", new SuccessAction().name("onSuccess").type("end"));
+
+        assertEquals(1, validator.validateComponents(components).size());
+    }
+
+    @Test
+    void validateComponentsFailureActions() {
+        Components components = new Components();
+        components.getFailureActions().put("onFailure", new FailureAction().name("onFailure").type("end"));
+
+        assertEquals(0, validator.validateComponents(components).size());
+    }
+
+    @Test
+    void validateComponentsFailureActionsInvalidKey() {
+        Components components = new Components();
+        components.getFailureActions().put("on failure", new FailureAction().name("onFailure").type("end"));
+
+        assertEquals(1, validator.validateComponents(components).size());
+    }
+
+    @Test
+    void parameterValueBoolean() {
+        Parameter parameter = new Parameter()
+                .name("flag")
+                .value(true)
+                .in("query");
+
+        assertEquals(0, validator.validateParameter(parameter, "w1", null).size());
+    }
+
+    @Test
+    void parameterValueNumber() {
+        Parameter parameter = new Parameter()
+                .name("page")
+                .value(42)
+                .in("query");
+
+        assertEquals(0, validator.validateParameter(parameter, "w1", null).size());
+    }
 
     @Test
     void isValidJsonPointer() {


### PR DESCRIPTION
## Summary

Adds the model fields and validator logic for the Arazzo 1.0 spec features that were previously absent.

### Model changes

| Class | Change |
|---|---|
| `Info` | Added optional `summary` field |
| `SuccessAction` | Added required `name` field |
| `FailureAction` | Added required `name` field |
| `Parameter` | `value` widened from `String` to `Object` (spec allows boolean, number, object, array, null) |
| `Workflow` | `dependsOn` changed from `String` to `List<String>` (spec defines it as an array) |
| `CriterionExpressionType` | New model for the `{ type, version }` expression type object (jsonpath/xpath) |
| `Criterion` | `type` now deserialises both plain strings and `CriterionExpressionType` objects via `CriterionTypeDeserializer`; typed accessors `getType()` and `getExpressionType()` provided |

### Validator changes

- **`arazzo` version**: validated against pattern `^1\.0\.\d+(-.+)?$`
- **`SourceDescription.name`**: validated against pattern `^[A-Za-z0-9_\-]+$`
- **`SuccessAction.name` / `FailureAction.name`**: both checked as required fields
- **`Criterion` expression type**: validates `type` is `jsonpath` or `xpath`, `version` is present, and `context` is provided
- **`validateComponents`**: now validates `successActions` and `failureActions` (key format + content)
- **`validateWorkflow`**: each entry in `dependsOn` is checked to reference an existing workflow

### Tests

All new features are covered by tests (30+ new test cases added).